### PR TITLE
monasca: enable Monasca barclamp

### DIFF
--- a/monasca.yml
+++ b/monasca.yml
@@ -29,7 +29,7 @@ barclamp:
   display: 'Monasca'
   description: 'OpenStack Monasca: Logging and Monitoring service for OpenStack'
   version: 0
-  user_managed: false
+  user_managed: true
   requires:
     - '@crowbar'
     - 'database'


### PR DESCRIPTION
This commit enables the Monasca barclamp and should become part of the main pull request https://github.com/crowbar/crowbar-openstack/pull/879 since with the merge of the main pull request the barclamp should become visible.